### PR TITLE
feat: PDF 문자 사용 가능 시 OCR 스킵

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Created: 2025-09-03T01:22:08
 - `pipeline/chunker.py` : 청킹 규칙(길이/타입/overlap)
 - `pipeline/embedder.py` : 임베딩 스텁(Qwen/OpenAI/경량 SBERT 지원)
 - `pipeline/vector_sink.py` : VectorDB 업서트(JSON 파일 기본, Milvus/FAISS 훅)
-- `ingest.py` : 전체 파이프라인 오케스트레이션(골격)
+- `ingest.py` : 전체 파이프라인 오케스트레이션(골격, PDF 내 텍스트 존재 시 OCR 생략)
 - `configs/config.yaml` : 파이프라인 파라미터
 - `requirements.txt` : 의존성 목록(스텁 상태, 선택 설치)
 
@@ -19,7 +19,7 @@ Created: 2025-09-03T01:22:08
 # 가상환경 권장
 python ingest.py --pdf path/to/file.pdf --out ./out --config ./configs/config.yaml
 ```
-> 주의: 현재 OCR/LLM/임베딩은 **스텁**입니다. 실제 엔진 연동 시 해당 파일들의 TODO 주석을 참고해 구현하세요.
+> 주의: 현재 OCR/LLM/임베딩은 **스텁**입니다. PDF에 텍스트가 포함되어 있으면 OCR 없이 처리하며, 스캔본 페이지에만 OCR이 동작합니다. 실제 엔진 연동 시 해당 파일들의 TODO 주석을 참고해 구현하세요.
 
 ## 저사양(CPU) 환경 실행
 - `configs/config.yaml` 은 기본적으로 GPU 없이 동작하도록 경량 SBERT 임베딩과 낮은 DPI(200)를 사용합니다.

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,6 +1,6 @@
 pipeline:
-  dpi: 200            # lower DPI for reduced memory usage
-  ocr_conf_threshold: 0.85
+  dpi: 200            # OCR용 이미지 렌더링 해상도 (텍스트 페이지는 OCR 생략)
+  ocr_conf_threshold: 0.85  # OCR 결과 신뢰도 임계치
 
 chunk:
   max_chars: 800

--- a/pipeline/pdf_to_image.py
+++ b/pipeline/pdf_to_image.py
@@ -18,6 +18,7 @@ def pdf_to_images(
     out_dir: str = "./out",
     fmt: str = "png",
     grayscale: bool = False,
+    page_numbers: List[int] | None = None,
 ) -> List[Dict]:
     """Convert a PDF into page images.
 
@@ -27,6 +28,7 @@ def pdf_to_images(
         out_dir: 출력 디렉터리
         fmt: 저장 포맷 (png, jpg 등)
         grayscale: True면 회색조, False면 RGB로 저장
+        page_numbers: 변환할 페이지 번호 리스트 (1-indexed). None이면 전체 페이지
 
     Returns:
         각 페이지에 대한 메타데이터 리스트. 페이지 번호, 이미지 경로, dpi,
@@ -37,7 +39,10 @@ def pdf_to_images(
     images: List[Dict] = []
 
     try:
+        selected = set(page_numbers) if page_numbers else None
         for page_no, page in enumerate(doc, start=1):
+            if selected and page_no not in selected:
+                continue
             # DPI 반영
             mat = fitz.Matrix(dpi / 72, dpi / 72)
 

--- a/pipeline/postprocess.py
+++ b/pipeline/postprocess.py
@@ -39,6 +39,17 @@ def assemble_units_from_page(page_json: Dict, page_no: int, mode: str) -> List[D
                 "conf": b.get("conf", avg_conf),
                 "heading_path": infer_heading_path(page_json, b)
             })
+    elif mode == "pdf_text":
+        text = page_json.get("text", "").replace("-\n", "").replace("\n", " ").strip()
+        if text:
+            units.append({
+                "type": "paragraph",
+                "text": text,
+                "page": page_no,
+                "source": "pdf_text",
+                "conf": 1.0,
+                "heading_path": []
+            })
     else:
         # vision fallback
         summaries = page_json.get("summaries", [])


### PR DESCRIPTION
## Summary
- extract text directly from PDFs and only render images/OCR for pages without text
- allow `pdf_to_images` to target specific pages
- unify postprocessing to handle both PDF text and OCR output
- document that OCR runs conditionally

## Testing
- `python -m py_compile ingest.py pipeline/pdf_to_image.py pipeline/postprocess.py`
- `pip install pymupdf` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68b94e971880832fba02e9cbdba643da