### PR TITLE
fix : 청킹 수정

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -4,8 +4,8 @@ pipeline:
 
 chunk:
   max_chars: 800
-  min_chars: 400
-  overlap_chars: 100
+  min_chars: 300
+  overlap_chars: 80
 
 embedder:
   provider: local

--- a/ingest.py
+++ b/ingest.py
@@ -132,6 +132,8 @@ def main():
             units.extend(
                 assemble_units_from_page(ocr_page, page_no=page_meta["page"], mode="ocr")
             )
+    # pdf_text만 인덱싱 (vision/ocr 결과는 별도 컬렉션으로 처리)
+    units = [u for u in units if u.get("source") == "pdf_text"]
 
     # 3) Exaone 기반 구조화/요약
     print("[INFO] Step 3: Structure & Summarize")

--- a/pipeline/chunker.py
+++ b/pipeline/chunker.py
@@ -3,10 +3,17 @@
 청킹(Chunking) 규칙: 길이 기반 + 타입 감지 + overlap
 """
 from typing import List, Dict
+import hashlib
 
-def split_into_chunks(units: List[Dict], max_chars=1400, min_chars=800, overlap_chars=200) -> List[Dict]:
-    chunks = []
-    buf = []
+
+def split_into_chunks(
+    units: List[Dict],
+    max_chars: int = 800,
+    min_chars: int = 300,
+    overlap_chars: int = 80,
+) -> List[Dict]:
+    chunks: List[Dict] = []
+    buf: List[Dict] = []
     cur = 0
 
     def flush():
@@ -14,28 +21,41 @@ def split_into_chunks(units: List[Dict], max_chars=1400, min_chars=800, overlap_
         if not buf:
             return
         text = "\n\n".join(x["text"] for x in buf if x.get("text"))
+        # block_type은 첫 unit 기준으로 동일 타입이면 그 타입, 아니면 mixed
+        types = {x.get("type", "paragraph") for x in buf}
+        block_type = types.pop() if len(types) == 1 else "mixed"
         meta = {
             "pages": sorted(list({x.get("page") for x in buf})),
             "heading_path": buf[0].get("heading_path", []) if buf else [],
-            "source": buf[0].get("source", "ocr") if buf else "ocr"
+            "source": buf[0].get("source", "ocr") if buf else "ocr",
+            "block_type": block_type,
         }
         chunks.append({"text": text, "meta": meta})
-        buf.clear(); cur = 0
+        buf.clear()
+        cur = 0
 
     for u in units:
         tlen = len(u.get("text", ""))
         # 표/코드/제목은 독립 청크로 다루는 것이 안전
         if u.get("type") in ("table", "code", "title"):
             flush()
-            chunks.append({"text": u.get("text",""), "meta":{
-                "pages":[u.get("page")], "heading_path": u.get("heading_path", []),
-                "source": u.get("source","ocr")
-            }})
+            chunks.append(
+                {
+                    "text": u.get("text", ""),
+                    "meta": {
+                        "pages": [u.get("page")],
+                        "heading_path": u.get("heading_path", []),
+                        "source": u.get("source", "ocr"),
+                        "block_type": u.get("type"),
+                    },
+                }
+            )
             continue
 
         if cur + tlen > max_chars and cur >= min_chars:
             flush()
-        buf.append(u); cur += tlen
+        buf.append(u)
+        cur += tlen
 
     flush()
 
@@ -49,6 +69,17 @@ def split_into_chunks(units: List[Dict], max_chars=1400, min_chars=800, overlap_
             with_ov.append({"text": joined, "meta": c["meta"]})
             prev_tail = text[-overlap_chars:]
         chunks = with_ov
+
+    # 내용 중복 제거
+    seen = set()
+    uniq_chunks: List[Dict] = []
+    for c in chunks:
+        h = hashlib.md5(c["text"].encode("utf-8")).hexdigest()
+        if h in seen:
+            continue
+        seen.add(h)
+        uniq_chunks.append(c)
+    chunks = uniq_chunks
 
     # ID 부여
     for i, c in enumerate(chunks, start=1):


### PR DESCRIPTION
## Summary
- shrink chunk size to 300-800 chars with overlap and deduplication
- clean PDF text into paragraph/list/table_row units with heading paths and block type
- index only pdf_text units and record block types in chunk metadata

## Testing
- `python -m py_compile ingest.py pipeline/chunker.py pipeline/postprocess.py`
- `python ingest.py --pdf pdf_in/test001.pdf --out out --config configs/config.yaml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68b951c292f8832f8fb32a8d758530c5